### PR TITLE
Ignore blank lines in cue file parsing

### DIFF
--- a/lib/cue.js
+++ b/lib/cue.js
@@ -46,13 +46,12 @@ exports = module.exports;
     }
 
     lines = fs.readFileSync(filename, {encoding: 'utf8', flag: 'r'}).toString().split('\n');
-    lines[0] = lines[0].replace(/^\uFEFF/, '');
 
     lines.forEach(function(line) {
-
-        lineParser = parseCommand(line);
-
-        commandMap[lineParser.command](lineParser.params, cuesheet);
+        if (! line.match(/^\s*$/)) {
+            lineParser = parseCommand(line);
+            commandMap[lineParser.command](lineParser.params, cuesheet);
+        };
     });
 
     return cuesheet;


### PR DESCRIPTION
I've got a large collection of music, much of which is in FLAC+CUE format, and the tool which generated those CUE files did so using Windows-style (\r\n) line endings. This apparently confuses Node's file reader, such that it appends an extra blank line to the array returned by fs.readFileSync, and that in turn causes cue-parser to choke during command parsing because no command exists on that line.

There's an argument to be made that I should've solved this by filtering my cue files such that no blank lines remain, but in the absence of a real standard for the format, I think it's at least as reasonable to consider that parsing code should defend itself against the presence of empty lines, which in most similar textual formats are simply ignored. (The GNU project [appears to agree](http://www.gnu.org/software/ccd2cue/manual/html_node/CUE-sheet-format.html), for whatever that's worth.)

That being the case, I've forked cue-parser and modified it to ignore blank lines, which is the subject of this pull request. (The request actually contains two commits; I initially thought the presence of a Unicode BOM, which is discouraged but not forbidden in UTF-8 text, was causing the problem. On realizing the true cause of the issue, I backed out that change.)
