### PR TITLE
ISO-8859-X encoded files are treated as binary

### DIFF
--- a/lib/cue.ts
+++ b/lib/cue.ts
@@ -45,10 +45,8 @@ export function parse(filename: string): ICueSheet {
   cuesheet.encoding = chardet.detect(fs.readFileSync(filename));
   let encoding = cuesheet.encoding;
 
-  switch (cuesheet.encoding) {
-    case 'ISO-8859-1':
-      encoding = 'binary';
-      break;
+  if (cuesheet.encoding.startsWith('ISO-8859-')) {
+    encoding = 'binary';
   }
 
   const lines = (fs.readFileSync(filename, {encoding, flag: 'r'}) as any)


### PR DESCRIPTION
This is to allow for edge cases where chardet detects some of the ISO-8859 variants, and we don't really care which one. In theory, any ISO-8559-X encoded file can be read as binary.

Attempt to fix #23 